### PR TITLE
Feat/scanned lote

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -1,5 +1,5 @@
-const VERSION_CODE = 14
-const VERSION = '24.1.4'
+const VERSION_CODE = 15
+const VERSION = '24.2.1'
 
 const versionString = `${VERSION} (${VERSION_CODE})`
 export default {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "1.18.2",
+    "@react-navigation/elements": "^1.3.21",
     "@react-navigation/native": "^6.1.9",
     "@react-navigation/native-stack": "^6.9.17",
     "axios": "^1.5.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,9 @@
 import {NavigationContainer} from '@react-navigation/native'
 import {createNativeStackNavigator} from '@react-navigation/native-stack'
+import {HeaderBackButton} from '@react-navigation/elements'
 import * as Linking from 'expo-linking'
 import {useAtomValue} from 'jotai'
-import {useEffect, useState} from 'react'
+import React, {useEffect, useState} from 'react'
 import {Platform, Text} from 'react-native'
 import NfcManager from 'react-native-nfc-manager'
 import {Callout} from './components/Callout'
@@ -60,14 +61,35 @@ export default function App(): JSX.Element {
           options={{title: 'Issue New Lote'}}
           component={Issue}
         />
+
         <Stack.Screen
           name="LoteDetail"
-          options={{title: 'Lote detail'}}
+          options={({navigation}) => ({
+            title: 'Lote Detail',
+            headerLeft: (props) => (
+              <HeaderBackButton
+                {...props}
+                onPress={() => {
+                  navigation.navigate('Home')
+                }}
+              />
+            ),
+          })}
           component={LoteDetail}
         />
         <Stack.Screen
           name="ScannedLote"
-          options={{title: 'Scanned Lote'}}
+          options={({navigation}) => ({
+            title: 'Scanned Lote',
+            headerLeft: (props) => (
+              <HeaderBackButton
+                {...props}
+                onPress={() => {
+                  navigation.navigate('Home')
+                }}
+              />
+            ),
+          })}
           component={ScannedLote}
         />
       </Stack.Navigator>

--- a/src/api.ts
+++ b/src/api.ts
@@ -42,7 +42,7 @@ interface getInvoiceApiResponse {
   lnurl_response: string
 }
 
-interface scanLnurlApiResponse {
+export interface scanLnurlApiResponse {
   domain: string
   tag: string
   callback: string

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -1,9 +1,9 @@
-import {Feather} from '@expo/vector-icons'
-import {useAtom, useAtomValue, useSetAtom} from 'jotai'
-import React, {useEffect} from 'react'
-import {Text, TouchableOpacity, View} from 'react-native'
-import {useApiCalls} from '../api'
-import {RecordsList} from '../components/Lotes'
+import { Feather } from '@expo/vector-icons'
+import { useAtom, useAtomValue, useSetAtom } from 'jotai'
+import React, { useEffect } from 'react'
+import { Text, TouchableOpacity, View } from 'react-native'
+import { useApiCalls } from '../api'
+import { RecordsList } from '../components/Lotes'
 import {
   allLotesValueAtom,
   balanceAtom,
@@ -12,8 +12,8 @@ import {
   recordsAtom,
   refreshCounterAtom,
 } from '../state/atoms'
-import {styles} from '../theme'
-import {readNfc} from '../utils/nfc'
+import { styles } from '../theme'
+import { readNfc } from '../utils/nfc'
 
 function Home({navigation}: {navigation: any}): JSX.Element {
   const isFetching = useAtomValue(isFetchingAtom)

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -1,9 +1,9 @@
-import { Feather } from '@expo/vector-icons'
-import { useAtom, useAtomValue, useSetAtom } from 'jotai'
-import React, { useEffect } from 'react'
-import { Text, TouchableOpacity, View } from 'react-native'
-import { useApiCalls } from '../api'
-import { RecordsList } from '../components/Lotes'
+import {Feather} from '@expo/vector-icons'
+import {useAtom, useAtomValue, useSetAtom} from 'jotai'
+import React, {useEffect} from 'react'
+import {Text, TouchableOpacity, View} from 'react-native'
+import {useApiCalls} from '../api'
+import {RecordsList} from '../components/Lotes'
 import {
   allLotesValueAtom,
   balanceAtom,
@@ -12,8 +12,8 @@ import {
   recordsAtom,
   refreshCounterAtom,
 } from '../state/atoms'
-import { styles } from '../theme'
-import { readNfc } from '../utils/nfc'
+import {styles} from '../theme'
+import {readNfc} from '../utils/nfc'
 
 function Home({navigation}: {navigation: any}): JSX.Element {
   const isFetching = useAtomValue(isFetchingAtom)
@@ -80,6 +80,12 @@ function Home({navigation}: {navigation: any}): JSX.Element {
     })()
   }
 
+  const handleCheckLotePress = (): void => {
+    navigation.navigate('ScannedLote', {
+      id: 'LNURL1DP68GURN8GHJ7MRWVF5HGUEWVDAZ7AMFW35XGUNPWUHKZURF9AMRZTMVDE6HYMP0G9V42MT9WAX5GCF58QUKG6MHXFQ5WURXFFZZ73EJWPJ8XJ6Z8924WNJ8TFPNYNJP893XJ7JENWYMQM',
+    })
+  }
+
   return (
     <View style={styles.container}>
       <Feather
@@ -122,6 +128,9 @@ function Home({navigation}: {navigation: any}): JSX.Element {
       </View>
       <Text>{'\n'} </Text>
       {returnAvailableBalance()}
+      <TouchableOpacity onPress={handleCheckLotePress} disabled={isFetching}>
+        <Text style={styles.link}>🔍 Check Lote</Text>
+      </TouchableOpacity>
     </View>
   )
 }

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -81,9 +81,17 @@ function Home({navigation}: {navigation: any}): JSX.Element {
   }
 
   const handleCheckLotePress = (): void => {
-    navigation.navigate('ScannedLote', {
-      id: 'LNURL1DP68GURN8GHJ7MRWVF5HGUEWVDAZ7AMFW35XGUNPWUHKZURF9AMRZTMVDE6HYMP0G9V42MT9WAX5GCF58QUKG6MHXFQ5WURXFFZZ73EJWPJ8XJ6Z8924WNJ8TFPNYNJP893XJ7JENWYMQM',
-    })
+    void (async () => {
+      try {
+        const lnurlFromNfc = await readNfc()
+        if (!lnurlFromNfc) return
+        navigation.navigate('ScannedLote', {
+          id: lnurlFromNfc,
+        })
+      } catch (error) {
+        console.error(error)
+      }
+    })()
   }
 
   return (

--- a/src/screens/ScannedLoteScreen.tsx
+++ b/src/screens/ScannedLoteScreen.tsx
@@ -1,14 +1,14 @@
-import React, {useEffect, useState} from 'react'
-import {Text, TouchableOpacity, View} from 'react-native'
-import {useAtom, useAtomValue} from 'jotai'
-import {recordsAtom, refreshCounterAtom, isFetchingAtom} from '../state/atoms'
-import {useApiCalls} from '../api'
-import type {scanLnurlApiResponse} from '../api'
+import { useAtom, useAtomValue } from 'jotai'
+import React, { useEffect, useState } from 'react'
+import { Text, TouchableOpacity, View } from 'react-native'
+import type { scanLnurlApiResponse } from '../api'
+import { useApiCalls } from '../api'
+import { isFetchingAtom, recordsAtom, refreshCounterAtom } from '../state/atoms'
 
-import {styles} from '../theme'
+import { styles } from '../theme'
 
 function ScannedLote({route, navigation}: any): JSX.Element {
-  const id = route.params
+  const {id} = route.params
   const records = useAtomValue(recordsAtom)
   const [refreshCounter, setRefreshCounter] = useAtom(refreshCounterAtom)
   const isFetching = useAtomValue(isFetchingAtom)
@@ -55,7 +55,7 @@ function ScannedLote({route, navigation}: any): JSX.Element {
     <View style={styles.container}>
       <Text style={styles.sectionHeader}>Lote contains promise of:</Text>
       <Text style={styles.header}>
-        {selectedRecord === null ? 'loading' : selectedRecord.maxWithdrawable}
+        {selectedRecord === null ? 'loading' : selectedRecord.maxWithdrawable/1000}
       </Text>
       <Text style={styles.subHeader}>sats</Text>
       <View style={styles.buttonContainer}>

--- a/src/screens/ScannedLoteScreen.tsx
+++ b/src/screens/ScannedLoteScreen.tsx
@@ -1,32 +1,80 @@
-import React from 'react'
-import {Text, View} from 'react-native'
+import React, {useEffect, useState} from 'react'
+import {Text, TouchableOpacity, View} from 'react-native'
+import {useAtom, useAtomValue} from 'jotai'
+import {recordsAtom, refreshCounterAtom, isFetchingAtom} from '../state/atoms'
+import {useApiCalls} from '../api'
+import type {scanLnurlApiResponse} from '../api'
 
 import {styles} from '../theme'
 
 function ScannedLote({route, navigation}: any): JSX.Element {
-  const {id} = route.params
+  const id = route.params
+  const records = useAtomValue(recordsAtom)
+  const [refreshCounter, setRefreshCounter] = useAtom(refreshCounterAtom)
+  const isFetching = useAtomValue(isFetchingAtom)
+  const [selectedRecord, setSelectedRecord] =
+    useState<scanLnurlApiResponse | null>(null)
+  const {scanLnurl, requestPayment, getInvoice} = useApiCalls()
 
-  // const isUsed = record.uses - record.used <= 0
+  useEffect(() => {
+    const checkScannedLote = async (): Promise<void> => {
+      const isLoteInternal = records.records.some(
+        (record) => record.lnurl === id
+      )
+      if (isLoteInternal) {
+        const record = records.records.find((record) => record.lnurl === id)
+        navigation.navigate('LoteDetail', {record})
+      } else {
+        const scanResultJson = await scanLnurl(id)
+        setSelectedRecord(scanResultJson)
+      }
+    }
+    checkScannedLote().catch((error) => {
+      console.error(error)
+    })
+  }, [id, records, navigation, scanLnurl])
+
+  const handleClaimButtonPress = (): void => {
+    void (async () => {
+      if (selectedRecord === null) {
+        return
+      }
+      try {
+        const temporaryAmount = selectedRecord.maxWithdrawable / 1000
+        const createdInvoice = await getInvoice(temporaryAmount)
+        await requestPayment(selectedRecord.callback, createdInvoice)
+        setRefreshCounter(refreshCounter + 1)
+        navigation.navigate('Home')
+      } catch (error) {
+        console.error(error)
+      }
+    })()
+  }
 
   return (
     <View style={styles.container}>
-      <Text style={styles.header}>Lote ID: {id}</Text>
-      {/* <Text style={styles.sectionHeader}>
-        {isUsed ? 'Lote contains promise of:' : 'Lote was already used'}
+      <Text style={styles.sectionHeader}>Lote contains promise of:</Text>
+      <Text style={styles.header}>
+        {selectedRecord === null ? 'loading' : selectedRecord.maxWithdrawable}
       </Text>
-      <Text style={styles.header}>{record.max_withdrawable}</Text>
       <Text style={styles.subHeader}>sats</Text>
       <View style={styles.buttonContainer}>
         <TouchableOpacity
           style={styles.button}
           onPress={handleClaimButtonPress}
-          disabled={isFetching}
+          disabled={isFetching || selectedRecord === null}
         >
           <Text style={styles.buttonText}>🫳 Claim Lote</Text>
         </TouchableOpacity>
+        <TouchableOpacity
+          style={styles.secondaryButton}
+          onPress={() => navigation.navigate('Home')}
+        >
+          <Text style={styles.buttonText}>🤜 Cancel</Text>
+        </TouchableOpacity>
       </View>
 
-      <Text style={styles.secondaryText}>{record.lnurl}</Text> */}
+      <Text style={styles.secondaryText}>{id}</Text>
     </View>
   )
 }

--- a/src/screens/ScannedLoteScreen.tsx
+++ b/src/screens/ScannedLoteScreen.tsx
@@ -1,20 +1,29 @@
-import { useAtom, useAtomValue } from 'jotai'
-import React, { useEffect, useState } from 'react'
-import { Text, TouchableOpacity, View } from 'react-native'
-import type { scanLnurlApiResponse } from '../api'
-import { useApiCalls } from '../api'
-import { isFetchingAtom, recordsAtom, refreshCounterAtom } from '../state/atoms'
+import {useAtom, useAtomValue} from 'jotai'
+import React, {useEffect, useRef, useState} from 'react'
+import {Text, TouchableOpacity, View} from 'react-native'
+import type {scanLnurlApiResponse} from '../api'
+import {useApiCalls} from '../api'
+import {
+  isFetchingAtom,
+  recordsAtom,
+  refreshCounterAtom,
+  adminKeyAtom,
+} from '../state/atoms'
 
-import { styles } from '../theme'
+import {styles} from '../theme'
 
 function ScannedLote({route, navigation}: any): JSX.Element {
   const {id} = route.params
   const records = useAtomValue(recordsAtom)
   const [refreshCounter, setRefreshCounter] = useAtom(refreshCounterAtom)
+  const adminKey = useAtomValue(adminKeyAtom)
   const isFetching = useAtomValue(isFetchingAtom)
   const [selectedRecord, setSelectedRecord] =
     useState<scanLnurlApiResponse | null>(null)
   const {scanLnurl, requestPayment, getInvoice} = useApiCalls()
+
+  const navigationRef = useRef(navigation)
+  const scanLnurlRef = useRef(scanLnurl)
 
   useEffect(() => {
     const checkScannedLote = async (): Promise<void> => {
@@ -23,16 +32,16 @@ function ScannedLote({route, navigation}: any): JSX.Element {
       )
       if (isLoteInternal) {
         const record = records.records.find((record) => record.lnurl === id)
-        navigation.navigate('LoteDetail', {record})
+        navigationRef.current.navigate('LoteDetail', {record})
       } else {
-        const scanResultJson = await scanLnurl(id)
+        const scanResultJson = await scanLnurlRef.current(id)
         setSelectedRecord(scanResultJson)
       }
     }
     checkScannedLote().catch((error) => {
       console.error(error)
     })
-  }, [id, records, navigation, scanLnurl])
+  }, [id, records])
 
   const handleClaimButtonPress = (): void => {
     void (async () => {
@@ -55,20 +64,28 @@ function ScannedLote({route, navigation}: any): JSX.Element {
     <View style={styles.container}>
       <Text style={styles.sectionHeader}>Lote contains promise of:</Text>
       <Text style={styles.header}>
-        {selectedRecord === null ? 'loading' : selectedRecord.maxWithdrawable/1000}
+        {selectedRecord === null
+          ? 'loading'
+          : selectedRecord.maxWithdrawable / 1000}
       </Text>
       <Text style={styles.subHeader}>sats</Text>
       <View style={styles.buttonContainer}>
         <TouchableOpacity
           style={styles.button}
           onPress={handleClaimButtonPress}
-          disabled={isFetching || selectedRecord === null}
+          disabled={isFetching || selectedRecord === null || !adminKey}
         >
           <Text style={styles.buttonText}>🫳 Claim Lote</Text>
         </TouchableOpacity>
+      </View>
+      <View style={styles.buttonContainer}>
         <TouchableOpacity
           style={styles.secondaryButton}
-          onPress={() => navigation.navigate('Home')}
+          onPress={() => {
+            adminKey
+              ? navigation.navigate('Home')
+              : navigation.navigate('Welcome')
+          }}
         >
           <Text style={styles.buttonText}>🤜 Cancel</Text>
         </TouchableOpacity>


### PR DESCRIPTION
- Adding option to check lote
- recognize internal one #31 
- adding external lote screen #61 
- Open app from `lotes://` uri handler
- Navigate to lote detail after adding `LNURL...` to uri handler